### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,6 @@
 name: Checks
+permissions:
+  contents: read
 on: 
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CeeBeeUK/laughing-arya/security/code-scanning/1](https://github.com/CeeBeeUK/laughing-arya/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply to all jobs. Since the workflow primarily involves reading repository contents (e.g., for dependency management and running tests), we will set `contents: read` as the minimal required permission. This ensures that the workflow operates with the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
